### PR TITLE
chore: "prettier/prettier Delete `␍`"

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,7 +1,7 @@
 {
   "arrowParens": "always",
   "bracketSpacing": true,
-  "endOfLine": "lf",
+  "endOfLine": "auto",
   "htmlWhitespaceSensitivity": "strict",
   "jsxSingleQuote": true,
   "printWidth": 100,


### PR DESCRIPTION
chrone(prettierrc):  :checkered_flag:  fixed "prettier/prettier Delete `␍`" in the Window10 OS  by change "endOfLine" from 'LF' to 'auto'.
Because 'LF' is not recognized by Windows system ** default **